### PR TITLE
Fix build error in main.go

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -36,7 +36,7 @@ func serveDefaultPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	http.ServeFile(w, r, defaultPage)
+	http.ServeFile(w, r, *defaultPage)
 }
 
 func ravenlog(msg string) {


### PR DESCRIPTION
Go build returns "cannot use defaultPage (type *string) as type string in argument to http.ServeFile" in version 1.12.6.  Changed to pass defaultPage as a pointer.